### PR TITLE
Add Task Role ARN value to Task Definition Saving

### DIFF
--- a/bin/ecs-deploy.js
+++ b/bin/ecs-deploy.js
@@ -54,6 +54,7 @@ function nextTask(task, containerName, image, tag) {
   return {
     family: task.family,
     volumes: task.volumes,
+    taskRoleArn: task.taskRoleArn,
     containerDefinitions: task.containerDefinitions.map(function(container) {
       if (container.name === containerName) {
         return nextContainer(container, image, tag);

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "node": ">=0.12"
   },
   "dependencies": {
-    "aws-sdk": "^2.6.2",
+    "aws-sdk": "2.6.2",
     "lodash": "3.10.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "node": ">=0.12"
   },
   "dependencies": {
-    "aws-sdk": "2.2.25",
+    "aws-sdk": "^2.6.2",
     "lodash": "3.10.1"
   },
   "devDependencies": {


### PR DESCRIPTION
With the Addition of Task Role IAM roles to task definitions, ecs-deploy was overwriting the value with NULL when a role was set in the previous task definition.
